### PR TITLE
a basic clarence to using the package with composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ $text = Porter2::stem('consistency');
 echo $text; // consist
 ```
 
+## Using with Composer package manager
+To use this library with Composer, simply run the following command:
+```
+composer require markfullmer/porter2
+```
+Then in Your PHP application, simply use the `Porter2` static class with `stem` function:
+```
+use markfullmer\Porter2\Porter2;
+var_dump(Porter2::stem('consistently'));
+```
+
 ## Stemmer Resources
 * [Step definition for the Porter 2 stemmer](http://snowball.tartarus.org/algorithms/english/stemmer.html)
 


### PR DESCRIPTION
When I tried to use this package, I thought it is a traditional PHP code, without composer autoloading. After a while I found that we can use it via `composer require` command. So in this PR the readme file is improved a little bit.